### PR TITLE
Send as file

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -10,4 +10,3 @@ ERR_REPORT_INTERVAL=<seconds between error summary report>
 REQUEST_TIMEOUT=60
 
 SAVE_EMAIL_LOGS=<whether to save raw eml files in logs folder (yes or no)>
-LONG_BODY_TO_HTML_THRESHOLD = <number of characters to convert long plain text email body to HTML format>

--- a/.env.template
+++ b/.env.template
@@ -10,3 +10,4 @@ ERR_REPORT_INTERVAL=<seconds between error summary report>
 REQUEST_TIMEOUT=60
 
 SAVE_EMAIL_LOGS=<whether to save raw eml files in logs folder (yes or no)>
+LONG_BODY_TO_HTML_THRESHOLD = <number of characters to convert long plain text email body to HTML format>

--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ pysocks = "*"
 markdownify = "*"
 requests = "*"
 bleach = "*"
+telegramify-markdown = "*"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ python-dotenv = "*"
 pysocks = "*"
 markdownify = "*"
 requests = "*"
+bleach = "*"
 
 [dev-packages]
 pylint = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "180d8fa1cc5318eaa9a7394a0b74a32c095fa163bfce8a72943d81f2d826b386"
+            "sha256": "d8339fbd25c0532c3528d768c50331318bfc70daaa03ee1e2814341739e6bb72"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -38,6 +38,15 @@
                 "sha256:b34053a581976c4c23064bb0e918a7f6f22273cf196c787946db323a6a2b7d84"
             ],
             "version": "==1.1.0"
+        },
+        "bleach": {
+            "hashes": [
+                "sha256:117d9c6097a7c3d22fd578fcd8d35ff1e125df6736f554da4e432fdd63f31e5e",
+                "sha256:123e894118b8a599fd80d3ec1a6d4cc7ce4e5882b1317a7e1ba69b56e95f991f"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==6.2.0"
         },
         "cachetools": {
             "hashes": [
@@ -325,6 +334,13 @@
                 "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"
             ],
             "version": "==0.2.13"
+        },
+        "webencodings": {
+            "hashes": [
+                "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78",
+                "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"
+            ],
+            "version": "==0.5.1"
         }
     },
     "develop": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d8339fbd25c0532c3528d768c50331318bfc70daaa03ee1e2814341739e6bb72"
+            "sha256": "3aa6557202a3cbc1dc13e0b6523e44efe9c3e3795c094b09926449bd237118e3"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -184,6 +184,14 @@
             "index": "pypi",
             "version": "==0.13.1"
         },
+        "mistletoe": {
+            "hashes": [
+                "sha256:1630f906e5e4bbe66fdeb4d29d277e2ea515d642bb18a9b49b136361a9818c9d",
+                "sha256:44a477803861de1237ba22e375c6b617690a31d2902b47279d1f8f7ed498a794"
+            ],
+            "markers": "python_version ~= '3.5'",
+            "version": "==1.4.0"
+        },
         "pysocks": {
             "hashes": [
                 "sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299",
@@ -264,6 +272,15 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==2.6"
+        },
+        "telegramify-markdown": {
+            "hashes": [
+                "sha256:9ac720dacf037fb6b0f4257354de3552b70d68ea0764bdaf96923f9f62d4a21a",
+                "sha256:b0a7aa45b381ff01fc9ec1b19f8eb3f971cb51654238a7290876035325a05e28"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==0.5.2"
         },
         "tornado": {
             "hashes": [

--- a/bot.py
+++ b/bot.py
@@ -347,7 +347,7 @@ def periodic_task() -> None:
 
                         if not interceptMail:
                             safeSendText(
-                                lambda text: updater.bot.send_message(chat_id=chat_id,reply_to_message_id=reply_to_message_id, text=text, parse_mode=ParseMode.HTML), # type: ignore[has-type]
+                                lambda text: updater.bot.send_message(chat_id=chat_id,reply_to_message_id=reply_to_message_id, text=text, parse_mode=ParseMode.MARKDOWN_V2), # type: ignore[has-type]
                                 text,
                             )
                             for filename, filemime, file_content in emailfiles:

--- a/bot.py
+++ b/bot.py
@@ -347,7 +347,7 @@ def periodic_task() -> None:
 
                         if not interceptMail:
                             safeSendText(
-                                lambda text: updater.bot.send_message(chat_id=chat_id,reply_to_message_id=reply_to_message_id, text=text), # type: ignore[has-type]
+                                lambda text: updater.bot.send_message(chat_id=chat_id,reply_to_message_id=reply_to_message_id, text=text, parse_mode=ParseMode.HTML), # type: ignore[has-type]
                                 text,
                             )
                             for filename, filemime, file_content in emailfiles:

--- a/bot.py
+++ b/bot.py
@@ -354,7 +354,7 @@ def periodic_task() -> None:
 
                         if not interceptMail:
                             safeSendText(
-                                lambda text: updater.bot.send_message(chat_id=chat_id,reply_to_message_id=reply_to_message_id, text=text, parse_mode=ParseMode.MARKDOWN_V2), # type: ignore[has-type]
+                                lambda text: updater.bot.send_message(chat_id=chat_id,reply_to_message_id=reply_to_message_id, text=text, parse_mode=ParseMode.MARKDOWN_V2, disable_web_page_preview=True), # type: ignore[has-type]
                                 text,
                             )
                             for filename, filemime, file_content in emailfiles:

--- a/bot.py
+++ b/bot.py
@@ -220,7 +220,7 @@ def safeSend(sender, content):
             sender(content)
             break
         except Exception:
-            logger.warning('cannot send tg msg (retry %d)', i, exc_info=True)
+            logger.warning('cannot send tg msg (retry %d)\n%s', i, content, exc_info=True)
         time.sleep(i * 5)
 
 emailClientCache: dict[tuple, EmailClientBase] = {}

--- a/bot.py
+++ b/bot.py
@@ -8,6 +8,7 @@ import time
 from traceback import format_exc
 from typing import Type
 import dataclasses
+import telegramify_markdown
 import typing
 from multiprocessing.pool import ThreadPool
 from telegram import Bot, ParseMode, Update
@@ -336,6 +337,7 @@ def periodic_task() -> None:
                         text = f'''New Email [{emailConf.email_addr}-{idx}]\n'''
                         emailbody, emailfiles = mail.format_email()
                         text += emailbody
+                        text = telegramify_markdown.markdownify(text, normalize_whitespace=True)
                         
                         interceptMail = False
                         for plugin_name, plugin in getAllPlugins():

--- a/bot.py
+++ b/bot.py
@@ -216,13 +216,18 @@ def safeSendText(sender, content):
         safeSend(sender, text)
 
 def safeSend(sender, content):
+    from telegram.error import RetryAfter
     for i in range(10):
         try:
             sender(content)
             break
+        except RetryAfter as e:
+            retry_after = e.retry_after + 1
+            logger.warning('Telegram flood control: retry after %d seconds (attempt %d)', retry_after, i)
+            time.sleep(retry_after)
         except Exception:
             logger.warning('cannot send tg msg (retry %d)\n%s', i, content, exc_info=True)
-        time.sleep(i * 5)
+            time.sleep(i * 5)
 
 emailClientCache: dict[tuple, EmailClientBase] = {}
 def getEmailClient(emailConf: EmailConf) -> EmailClientBase:

--- a/utils/conf.py
+++ b/utils/conf.py
@@ -17,7 +17,8 @@ class Conf:
     
     SAVE_EMAIL_LOGS: bool = False
     ENABLED_PLUGINS: str = ''
-    
+    LONG_BODY_TO_HTML_THRESHOLD: int = 0
+
     _defaultValues: dict | None = None
     @classmethod
     def _reloadConf(cls):

--- a/utils/conf.py
+++ b/utils/conf.py
@@ -17,7 +17,6 @@ class Conf:
     
     SAVE_EMAIL_LOGS: bool = False
     ENABLED_PLUGINS: str = ''
-    LONG_BODY_TO_HTML_THRESHOLD: int = 0
 
     _defaultValues: dict | None = None
     @classmethod

--- a/utils/mail.py
+++ b/utils/mail.py
@@ -55,6 +55,7 @@ class Email(object):
         mail_str += "Date: %s\n" % self.date
         mail_str += "ID: %s\n" % self.id
         mail_str += "\n"
+        mail_str = html.escape(mail_str)
         mainbody = self.text
         if not self.text or len(self.text) < 20: # not like a real email
             mainbody = self.html or self.text or ''
@@ -68,11 +69,23 @@ class Email(object):
                 mainbody = mainbody.decode('utf-8', errors='replace')
             except Exception:
                 mainbody = str(mainbody)
+
+        additional_parts = ""
+        if self.additional_parts:
+            additional_parts += '\n\nAdditional Parts:'
+            for part in self.additional_parts:
+                part: MailPart
+                part_name = part.filename
+                part_content = part.get_payload()
+                additional_parts += f'\n- {part_name} ({part.type}, size {len(part_content)})'
+                retfiles.append((part_name, part.type, part_content))
+        additional_parts = html.escape(additional_parts)
+
         # Long body: move to .htm attachment, keep short preview in message (only if threshold > 0)
         from utils.conf import Conf
-        threshold = Conf.LONG_BODY_TO_HTML_THRESHOLD
+        threshold = Conf.LONG_BODY_TO_HTML_THRESHOLD or 4096 - len(mail_str) - len(additional_parts) - 128
 
-        if threshold > 0 and isinstance(mainbody, str) and len(mainbody) > threshold:
+        if threshold > 0 and isinstance(mainbody, str) and len(html.escape(mainbody)) > threshold:
             if self.html_raw:
                 html_payload = self.html_raw if isinstance(self.html_raw, str) else str(self.html_raw)
             else:
@@ -84,13 +97,7 @@ class Email(object):
             # Insert body.htm as the first attachment
             retfiles.insert(0, ("body.html", "text/html", html_payload.encode("utf-8")))
             mainbody = mainbody[:threshold] + "..."
-        if self.additional_parts:
-            mainbody += '\n\nAdditional Parts:'
-            for part in self.additional_parts:
-                part: MailPart
-                part_name = part.filename
-                part_content = part.get_payload()
-                mainbody += f'\n- {part_name} ({part.type}, size {len(part_content)})'
-                retfiles.append((part_name, part.type, part_content))
-        mail_str += mainbody
+
+        mail_str += f'<blockquote expandable>{html.escape(mainbody)}</blockquote>'
+        mail_str += additional_parts
         return mail_str, retfiles

--- a/utils/mail.py
+++ b/utils/mail.py
@@ -4,7 +4,7 @@ from pyzmail.parse import MailPart # type: ignore
 import re
 import bleach
 from markdownify import markdownify as md
-
+import telegramify_markdown
 import html
 
 import logging
@@ -60,7 +60,6 @@ class Email(object):
                 elif is_body.startswith('text/') or (
                     not is_body and not mailpart.type): # strange email with none mime
                     payload, used_charset = decode_text(mailpart.get_payload(), mailpart.charset, None)
-                    self.text = html.unescape(payload)
                 else:
                     self.additional_parts.append(mailpart)
         except Exception as e:
@@ -76,7 +75,6 @@ class Email(object):
         mail_str += "Date: %s\n" % self.date
         mail_str += "ID: %s\n" % self.id
         mail_str += "\n"
-        mail_str = html.escape(mail_str)
         mainbody = self.text
         if not self.text or len(self.text) < 20: # not like a real email
             mainbody = self.html or self.text or ''
@@ -91,6 +89,12 @@ class Email(object):
             except Exception:
                 mainbody = str(mainbody)
 
+        # Add >
+        mainbody_quote = ""
+        for line in mainbody.splitlines():
+            mainbody_quote += '> ' + line + '\n'
+        mainbody = mainbody_quote.rstrip('\n')
+
         additional_parts = ""
         if self.additional_parts:
             additional_parts += '\n\nAdditional Parts:'
@@ -100,7 +104,6 @@ class Email(object):
                 part_content = part.get_payload()
                 additional_parts += f'\n- {part_name} ({part.type}, size {len(part_content)})'
                 retfiles.append((part_name, part.type, part_content))
-        additional_parts = html.escape(additional_parts)
 
         # Long body: move to .htm attachment, keep short preview in message (only if threshold > 0)
         from utils.conf import Conf
@@ -119,6 +122,7 @@ class Email(object):
             retfiles.insert(0, ("body.html", "text/html", html_payload.encode("utf-8")))
             mainbody = mainbody[:threshold] + "..."
 
-        mail_str += f'<blockquote expandable>\n{mainbody}</blockquote>'
+        mail_str += mainbody
         mail_str += additional_parts
+        mail_str = telegramify_markdown.markdownify(mail_str)
         return mail_str, retfiles

--- a/utils/mail.py
+++ b/utils/mail.py
@@ -124,5 +124,5 @@ class Email(object):
 
         mail_str += mainbody
         mail_str += additional_parts
-        mail_str = telegramify_markdown.markdownify(mail_str)
+        mail_str = telegramify_markdown.markdownify(mail_str, normalize_whitespace=True)
         return mail_str, retfiles

--- a/utils/mail.py
+++ b/utils/mail.py
@@ -119,7 +119,6 @@ class Email(object):
                 )
             # Insert body.htm as the first attachment
             retfiles.insert(0, ("body.html", "text/html", html_payload.encode("utf-8")))
-            # mainbody = mainbody[:threshold] + "..." we need to cut by lines to avoid broken markdown
             mainbody_lines = []
             current_length = 0
             while current_length < threshold - 4:
@@ -131,7 +130,7 @@ class Email(object):
                     break
                 mainbody_lines.append(line)
                 current_length += len(line) + 1
-            mainbody = '\n'.join(mainbody_lines) + "..."
+            mainbody = '\n'.join(mainbody_lines) + "……"
 
         mail_str += mainbody
         mail_str += additional_parts

--- a/utils/mail.py
+++ b/utils/mail.py
@@ -106,7 +106,7 @@ class Email(object):
                 retfiles.append((part_name, part.type, part_content))
 
         # Long body: move to .htm attachment, keep short preview in message (only if threshold > 0)
-        threshold = MAX_MESSAGE_LENGTH - len(mail_str) - len(additional_parts) - 128
+        threshold = MAX_MESSAGE_LENGTH - len(mail_str) - len(additional_parts) - 1280 # escape will increase size
 
         if threshold > 0 and isinstance(mainbody, str) and len(mainbody) > threshold:
             if self.html_raw:

--- a/utils/mail.py
+++ b/utils/mail.py
@@ -91,8 +91,15 @@ class Email(object):
 
         # Add >
         mainbody_quote = ""
+        last_line_empty = True
         for line in mainbody.splitlines():
-            mainbody_quote += '> ' + line + '\n'
+            if line.strip() != "":
+                last_line_empty = False
+                mainbody_quote += '> ' + line + '\n'
+            else:
+                if not last_line_empty:
+                    mainbody_quote += '> \n'
+                last_line_empty = True
         mainbody = mainbody_quote.rstrip('\n')
 
         additional_parts = ""

--- a/utils/mail.py
+++ b/utils/mail.py
@@ -81,15 +81,6 @@ class Email(object):
             mainbody = self.html or self.text or ''
         retfiles: List[Tuple[Optional[str], Optional[str], Optional[bytes]]] = []
 
-        # Normalize body to str
-        if mainbody is None:
-            mainbody = ''
-        elif isinstance(mainbody, bytes):
-            try:
-                mainbody = mainbody.decode('utf-8', errors='replace')
-            except Exception:
-                mainbody = str(mainbody)
-
         # Add >
         mainbody_quote = ""
         last_line_empty = True

--- a/utils/mail.py
+++ b/utils/mail.py
@@ -1,6 +1,7 @@
 from typing import List, Optional, Tuple, Union
 from pyzmail import PyzMessage, decode_text # type: ignore
 from pyzmail.parse import MailPart # type: ignore
+import html
 
 import logging
 logger = logging.getLogger(__name__)
@@ -19,15 +20,16 @@ class Email(object):
             self.sender = msg.get_address('from')
             self.date = msg.get_decoded_header('date', '')
             self.id = msg.get_decoded_header('message-id', '')
-
             self.text = None
             self.html = None
+            self.html_raw = None
             self.additional_parts = []
             for mailpart in msg.mailparts:
                 mailpart: MailPart
                 is_body = mailpart.is_body or ''
                 if is_body.startswith('text/html'):
-                    payload, used_charset=decode_text(mailpart.get_payload(), mailpart.charset, None)
+                    payload, used_charset = decode_text(mailpart.get_payload(), mailpart.charset, None)
+                    self.html_raw = payload
                     try:
                         from markdownify import markdownify as md # type: ignore
                         self.html = md(payload)
@@ -36,7 +38,7 @@ class Email(object):
                         self.html = payload
                 elif is_body.startswith('text/') or (
                     not is_body and not mailpart.type): # strange email with none mime
-                    payload, used_charset=decode_text(mailpart.get_payload(), mailpart.charset, None)
+                    payload, used_charset = decode_text(mailpart.get_payload(), mailpart.charset, None)
                     self.text = payload
                 else:
                     self.additional_parts.append(mailpart)
@@ -57,8 +59,33 @@ class Email(object):
         if not self.text or len(self.text) < 20: # not like a real email
             mainbody = self.html or self.text or ''
         retfiles: List[Tuple[Optional[str], Optional[str], Optional[bytes]]] = []
+
+        # Normalize body to str
+        if mainbody is None:
+            mainbody = ''
+        elif isinstance(mainbody, bytes):
+            try:
+                mainbody = mainbody.decode('utf-8', errors='replace')
+            except Exception:
+                mainbody = str(mainbody)
+        # Long body: move to .htm attachment, keep short preview in message (only if threshold > 0)
+        from utils.conf import Conf
+        threshold = Conf.LONG_BODY_TO_HTML_THRESHOLD
+
+        if threshold > 0 and isinstance(mainbody, str) and len(mainbody) > threshold:
+            if self.html_raw:
+                html_payload = self.html_raw if isinstance(self.html_raw, str) else str(self.html_raw)
+            else:
+                safe_text = html.escape(mainbody).replace("\n", "<br/>\n")
+                html_payload = (
+                    "<html><head><meta charset='utf-8'></head>"
+                    "<body><pre style='white-space:pre-wrap'>" + safe_text + "</pre></body></html>"
+                )
+            # Insert body.htm as the first attachment
+            retfiles.insert(0, ("body.html", "text/html", html_payload.encode("utf-8")))
+            mainbody = mainbody[:threshold] + "..."
         if self.additional_parts:
-            mainbody += f'\n\nAdditional Parts:'
+            mainbody += '\n\nAdditional Parts:'
             for part in self.additional_parts:
                 part: MailPart
                 part_name = part.filename

--- a/utils/mail.py
+++ b/utils/mail.py
@@ -59,7 +59,8 @@ class Email(object):
 
                 elif is_body.startswith('text/') or (
                     not is_body and not mailpart.type): # strange email with none mime
-                    payload, used_charset = decode_text(mailpart.get_payload(), mailpart.charset, None)
+                    payload, used_charset=decode_text(mailpart.get_payload(), mailpart.charset, None)
+                    self.text = payload
                 else:
                     self.additional_parts.append(mailpart)
         except Exception as e:

--- a/utils/mail.py
+++ b/utils/mail.py
@@ -107,7 +107,7 @@ class Email(object):
                 retfiles.append((part_name, part.type, part_content))
 
         # Long body: move to .htm attachment, keep short preview in message (only if threshold > 0)
-        threshold = MAX_MESSAGE_LENGTH - len(mail_str) - len(additional_parts) - 512
+        threshold = MAX_MESSAGE_LENGTH - len(mail_str) - len(additional_parts) - 128
 
         if threshold > 0 and isinstance(mainbody, str) and len(mainbody) > threshold:
             if self.html_raw:
@@ -120,7 +120,16 @@ class Email(object):
                 )
             # Insert body.htm as the first attachment
             retfiles.insert(0, ("body.html", "text/html", html_payload.encode("utf-8")))
-            mainbody = mainbody[:threshold] + "..."
+            # mainbody = mainbody[:threshold] + "..." we need to cut by lines to avoid broken markdown
+            mainbody_lines = []
+            current_length = 0
+            for line in mainbody.splitlines(keepends=True):
+                line_length = len(line)
+                if current_length + line_length > threshold - 4:  # 4 for "...\n"
+                    mainbody_lines.append("...\n")
+                    break
+                mainbody_lines.append(line)
+                current_length += line_length
 
         mail_str += mainbody
         mail_str += additional_parts

--- a/utils/mail.py
+++ b/utils/mail.py
@@ -4,7 +4,6 @@ from pyzmail.parse import MailPart # type: ignore
 import re
 import bleach
 from markdownify import markdownify as md
-import telegramify_markdown
 import html
 from telegram.constants import MAX_MESSAGE_LENGTH
 
@@ -136,5 +135,4 @@ class Email(object):
 
         mail_str += mainbody
         mail_str += additional_parts
-        mail_str = telegramify_markdown.markdownify(mail_str, normalize_whitespace=True)
         return mail_str, retfiles

--- a/utils/mail.py
+++ b/utils/mail.py
@@ -32,7 +32,8 @@ class Email(object):
                     self.html_raw = payload
                     try:
                         from markdownify import markdownify as md # type: ignore
-                        self.html = md(payload)
+                        self.text = md(payload)
+                        self.html = payload
                     except Exception:
                         logger.warning("cannot use markdownify to convert html, fallback to raw HTML instead.")
                         self.html = payload

--- a/utils/mail.py
+++ b/utils/mail.py
@@ -1,6 +1,8 @@
 from typing import List, Optional, Tuple, Union
 from pyzmail import PyzMessage, decode_text # type: ignore
 from pyzmail.parse import MailPart # type: ignore
+import re
+import bleach
 import html
 
 import logging
@@ -30,17 +32,32 @@ class Email(object):
                 if is_body.startswith('text/html'):
                     payload, used_charset = decode_text(mailpart.get_payload(), mailpart.charset, None)
                     self.html_raw = payload
-                    try:
-                        from markdownify import markdownify as md # type: ignore
-                        self.text = md(payload)
-                        self.html = payload
-                    except Exception:
-                        logger.warning("cannot use markdownify to convert html, fallback to raw HTML instead.")
-                        self.html = payload
+                    allowed_tags = [
+                        'b', 'strong', 'i', 'em', 'u', 'ins', 's', 'strike', 'del',
+                        'tg-spoiler', 'a', 'tg-emoji', 'code', 'pre', 'br'
+                    ]
+                    allowed_attributes = {
+                        'a': ['href'],
+                        'code': ['class']
+                    }
+                    allowed_protocols = ['http', 'https', 'tg']
+                    payload = re.sub(r'<style[^>]*>.*?</style>', '', payload, flags=re.DOTALL | re.IGNORECASE)
+                    cleaned_html = bleach.clean(
+                        payload,
+                        tags=allowed_tags,
+                        attributes=allowed_attributes,
+                        protocols=allowed_protocols,
+                        strip=True,
+                        strip_comments=True,
+                    )
+                    lines = cleaned_html.splitlines()
+                    non_empty_lines = [line for line in lines if line.strip()]
+                    self.html = "\n".join(non_empty_lines)
+
                 elif is_body.startswith('text/') or (
                     not is_body and not mailpart.type): # strange email with none mime
                     payload, used_charset = decode_text(mailpart.get_payload(), mailpart.charset, None)
-                    self.text = payload
+                    self.text = html.unescape(payload)
                 else:
                     self.additional_parts.append(mailpart)
         except Exception as e:
@@ -86,7 +103,7 @@ class Email(object):
         from utils.conf import Conf
         threshold = Conf.LONG_BODY_TO_HTML_THRESHOLD or 4096 - len(mail_str) - len(additional_parts) - 128
 
-        if threshold > 0 and isinstance(mainbody, str) and len(html.escape(mainbody)) > threshold:
+        if threshold > 0 and isinstance(mainbody, str) and len(mainbody) > threshold:
             if self.html_raw:
                 html_payload = self.html_raw if isinstance(self.html_raw, str) else str(self.html_raw)
             else:
@@ -99,6 +116,6 @@ class Email(object):
             retfiles.insert(0, ("body.html", "text/html", html_payload.encode("utf-8")))
             mainbody = mainbody[:threshold] + "..."
 
-        mail_str += f'<blockquote expandable>{html.escape(mainbody)}</blockquote>'
+        mail_str += f'<blockquote expandable>\n{mainbody}</blockquote>'
         mail_str += additional_parts
         return mail_str, retfiles

--- a/utils/mail.py
+++ b/utils/mail.py
@@ -6,6 +6,7 @@ import bleach
 from markdownify import markdownify as md
 import telegramify_markdown
 import html
+from telegram.constants import MAX_MESSAGE_LENGTH
 
 import logging
 logger = logging.getLogger(__name__)
@@ -106,8 +107,7 @@ class Email(object):
                 retfiles.append((part_name, part.type, part_content))
 
         # Long body: move to .htm attachment, keep short preview in message (only if threshold > 0)
-        from utils.conf import Conf
-        threshold = Conf.LONG_BODY_TO_HTML_THRESHOLD or 4096 - len(mail_str) - len(additional_parts) - 128
+        threshold = MAX_MESSAGE_LENGTH - len(mail_str) - len(additional_parts) - 512
 
         if threshold > 0 and isinstance(mainbody, str) and len(mainbody) > threshold:
             if self.html_raw:

--- a/utils/mail.py
+++ b/utils/mail.py
@@ -123,13 +123,16 @@ class Email(object):
             # mainbody = mainbody[:threshold] + "..." we need to cut by lines to avoid broken markdown
             mainbody_lines = []
             current_length = 0
-            for line in mainbody.splitlines(keepends=True):
-                line_length = len(line)
-                if current_length + line_length > threshold - 4:  # 4 for "...\n"
-                    mainbody_lines.append("...\n")
+            while current_length < threshold - 4:
+                next_newline = mainbody.find('\n', current_length)
+                if next_newline == -1:
+                    next_newline = len(mainbody)
+                line = mainbody[current_length:next_newline]
+                if current_length + len(line) + 1 > threshold:
                     break
                 mainbody_lines.append(line)
-                current_length += line_length
+                current_length += len(line) + 1
+            mainbody = '\n'.join(mainbody_lines) + "..."
 
         mail_str += mainbody
         mail_str += additional_parts

--- a/utils/mail.py
+++ b/utils/mail.py
@@ -3,6 +3,8 @@ from pyzmail import PyzMessage, decode_text # type: ignore
 from pyzmail.parse import MailPart # type: ignore
 import re
 import bleach
+from markdownify import markdownify as md
+
 import html
 
 import logging
@@ -53,6 +55,7 @@ class Email(object):
                     lines = cleaned_html.splitlines()
                     non_empty_lines = [line for line in lines if line.strip()]
                     self.html = "\n".join(non_empty_lines)
+                    self.text = md(self.html)
 
                 elif is_body.startswith('text/') or (
                     not is_body and not mailpart.type): # strange email with none mime


### PR DESCRIPTION
1. Handle telegram error RetryAfter correctly
2. Add `telegramify_markdown`, enable to send in markdown format
3. disable web preview
4. Remove style
5. Add `bleach` to clean up html before feed to markdownify
6. Use blockquote expandable to minimize the space need
7. If the email is too long, send the rest in raw html